### PR TITLE
Added Menu Items placeholder page

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -15,6 +15,8 @@ import PlaceholderIndexPage from "main/pages/Placeholder/PlaceholderIndexPage";
 import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage";
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
+import MenuItemPage from "main/pages/MenuItem/MenuItemPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -93,6 +95,15 @@ function App() {
               exact
               path="/placeholder/create"
               element={<PlaceholderCreatePage />}
+            />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route
+              exact
+              path="/diningcommons/:date-time/:dining-commons-code/:meal"
+              element={<MenuItemPage />}
             />
           </>
         )}

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -69,6 +69,12 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/placeholder">
                     Placeholder
                   </Nav.Link>
+                  <Nav.Link
+                    as={Link}
+                    to="/diningcommons/:date-time/:dining-commons-code/:meal"
+                  >
+                    Menu Items
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/MenuItem/MenuItemPage.js
+++ b/frontend/src/main/pages/MenuItem/MenuItemPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MenuItemPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Menu Item page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/MenuItem/MenuItemPage.test.js
+++ b/frontend/src/tests/pages/MenuItem/MenuItemPage.test.js
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import MenuItemPage from "main/pages/MenuItem/MenuItemPage";
+
+describe("PlaceholderIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MenuItemPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Menu Item page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Menu Item page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
closes: #18 

Added a placeholder page that will display menu items eventually. Right now, it can be accessed via the navbar and the route /diningcommons/:date-time/:dining-commons-code/:meal. 
Frontend changes:
- new link in Navbar that takes you to the placeholder Menu Items page. 
- placeholder menu items page

![Screenshot 2024-11-20 144141](https://github.com/user-attachments/assets/4db7c821-d6ef-4c57-be5c-5ddd546de27a)
![Screenshot 2024-11-20 144155](https://github.com/user-attachments/assets/8bdf8b82-2201-4059-810b-3fbc9e56e1e9)

Storybook link: https://6736bc30cc8f2118f61238ed-hjeoodpayj.chromatic.com/?path=/docs/pages-homepage--docs

Dokku: https://dining-qa.dokku-15.cs.ucsb.edu
Make sure the frontend changes described above are visible on dokku.