### PR TITLE
Added endpoint for meals

### DIFF
--- a/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBAPIMenuController.java
+++ b/src/main/java/edu/ucsb/cs156/dining/controllers/UCSBAPIMenuController.java
@@ -1,0 +1,46 @@
+package edu.ucsb.cs156.dining.controllers;
+
+import edu.ucsb.cs156.dining.models.Meal;
+import edu.ucsb.cs156.dining.services.UCSBAPIMenuService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/** Controller for UCSB Dining Menu API */
+@Tag(name = "UCSBAPIMenuController")
+@RestController
+@RequestMapping("/api/diningcommons")
+@Slf4j
+public class UCSBAPIMenuController {
+
+  @Autowired
+  private UCSBAPIMenuService menuService;
+
+  /**
+   * Endpoint to fetch all meals served in a particular dining commons on a specific date.
+   *
+   * @param dateTime the date (in YYYY-MM-DD format)
+   * @param diningCommonsCode the dining commons code
+   * @return a list of meals
+   * @throws Exception if the API request fails
+   */
+  @Operation(summary = "Get all meals for a specific date and dining commons")
+  @PreAuthorize("hasRole('ROLE_USER')")
+  @GetMapping("/{dateTime}/{diningCommonsCode}")
+  public List<Meal> getMeals(
+      @PathVariable String dateTime,
+      @PathVariable String diningCommonsCode) throws Exception {
+    log.info("Fetching meals for date: {} and dining commons: {}", dateTime, diningCommonsCode);
+    return menuService.getMeals(dateTime, diningCommonsCode);
+  }
+
+
+}

--- a/src/main/java/edu/ucsb/cs156/dining/models/Meal.java
+++ b/src/main/java/edu/ucsb/cs156/dining/models/Meal.java
@@ -1,0 +1,12 @@
+package edu.ucsb.cs156.dining.models;
+
+import lombok.Data;
+
+/**
+ * Represents a Meal returned by the UCSB Dining Menu API.
+ */
+@Data
+public class Meal {
+    private String name;
+    private String code;
+}

--- a/src/main/java/edu/ucsb/cs156/dining/services/UCSBAPIMenuService.java
+++ b/src/main/java/edu/ucsb/cs156/dining/services/UCSBAPIMenuService.java
@@ -1,0 +1,65 @@
+package edu.ucsb.cs156.dining.services;
+
+import edu.ucsb.cs156.dining.models.Meal;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+/** Service class to interact with UCSB Dining Menu API */
+@Service
+@Slf4j
+public class UCSBAPIMenuService {
+
+  @Value("${app.ucsb.api.consumer_key}")
+  private String apiKey;
+
+  private final RestTemplate restTemplate;
+
+  public UCSBAPIMenuService(RestTemplateBuilder restTemplateBuilder) {
+    this.restTemplate = restTemplateBuilder.build();
+  }
+
+  private static final String  MENU_ENDPOINT =
+      "https://api.ucsb.edu/dining/menu/v1/";
+
+  /**
+   * Fetches all meals served in a particular dining commons on a specific date.
+   *
+   * @param dateTime the date (in YYYY-MM-DD format)
+   * @param diningCommonsCode the dining commons code
+   * @return a list of meals (e.g., breakfast, lunch, dinner)
+   * @throws Exception if the API request fails
+   */
+  public List<Meal> getMeals(String dateTime, String diningCommonsCode) throws Exception {
+    String url = String.format("%s%s/%s", MENU_ENDPOINT, dateTime, diningCommonsCode);
+
+    HttpHeaders headers = new HttpHeaders();
+    headers.set("ucsb-api-key", this.apiKey);
+    headers.set("accept", "application/json");
+
+    HttpEntity<String> entity = new HttpEntity<>("body", headers);
+
+    log.info("Fetching meals for date: {}, dining commons: {}", dateTime, diningCommonsCode);
+
+    // Use RestTemplate to fetch data
+    ResponseEntity<Meal[]> response = restTemplate.exchange(
+        url, HttpMethod.GET, entity, Meal[].class);
+
+    Meal[] mealsArray = response.getBody();
+    if (mealsArray == null) {
+      throw new Exception("Failed to fetch meals data from API");
+    }
+
+    return List.of(mealsArray);
+  }
+
+
+}

--- a/src/test/java/edu/ucsb/cs156/dining/services/UCSBAPIMenuServiceTest.java
+++ b/src/test/java/edu/ucsb/cs156/dining/services/UCSBAPIMenuServiceTest.java
@@ -1,0 +1,103 @@
+package edu.ucsb.cs156.dining.services;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.*;
+
+import edu.ucsb.cs156.dining.models.Meal;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.util.List;
+
+@RestClientTest(UCSBAPIMenuService.class)
+public class UCSBAPIMenuServiceTest {
+
+    @Autowired
+    private UCSBAPIMenuService menuService;
+
+    @Autowired
+    private MockRestServiceServer mockServer;
+
+    @MockBean
+    private edu.ucsb.cs156.dining.services.wiremock.WiremockService wiremockService;
+
+    @Value("${app.ucsb.api.consumer_key}")
+    private String apiKey;
+
+    @Test
+    public void testGetMeals_Success() throws Exception {
+        // Arrange: Mock successful API response
+        String mockResponse = """
+            [
+                { "name": "Breakfast", "code": "breakfast" },
+                { "name": "Lunch", "code": "lunch" },
+                { "name": "Dinner", "code": "dinner" }
+            ]
+        """;
+
+        String expectedUrl = "https://api.ucsb.edu/dining/menu/v1/2024-11-20/de-la-guerra";
+
+        mockServer.expect(requestTo(expectedUrl))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andExpect(header("accept", "application/json"))
+                .andRespond(withSuccess(mockResponse, MediaType.APPLICATION_JSON));
+
+        // Act
+        List<Meal> result = menuService.getMeals("2024-11-20", "de-la-guerra");
+
+        // Assert
+        assertNotNull(result);
+        assertEquals(3, result.size());
+
+        Meal breakfast = result.get(0);
+        assertEquals("Breakfast", breakfast.getName());
+        assertEquals("breakfast", breakfast.getCode());
+
+        Meal lunch = result.get(1);
+        assertEquals("Lunch", lunch.getName());
+        assertEquals("lunch", lunch.getCode());
+
+        Meal dinner = result.get(2);
+        assertEquals("Dinner", dinner.getName());
+        assertEquals("dinner", dinner.getCode());
+    }
+
+    @Test
+    public void testGetMeals_NullResponse() {
+        // Arrange: Mock API response with null body
+        String expectedUrl = "https://api.ucsb.edu/dining/menu/v1/2024-11-20/de-la-guerra";
+
+        mockServer.expect(requestTo(expectedUrl))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withNoContent()); // Simulates a 204 No Content response
+
+        // Act & Assert
+        Exception exception = assertThrows(Exception.class, () -> {
+            menuService.getMeals("2024-11-20", "de-la-guerra");
+        });
+        assertEquals("Failed to fetch meals data from API", exception.getMessage());
+    }
+
+    @Test
+    public void testGetMeals_InvalidApiKey() {
+        // Arrange: Mock API response with 401 Unauthorized
+        String expectedUrl = "https://api.ucsb.edu/dining/menu/v1/2024-11-20/de-la-guerra";
+
+        mockServer.expect(requestTo(expectedUrl))
+                .andExpect(header("ucsb-api-key", apiKey))
+                .andRespond(withUnauthorizedRequest());
+
+        // Act & Assert
+        Exception exception = assertThrows(Exception.class, () -> {
+            menuService.getMeals("2024-11-20", "de-la-guerra");
+        });
+        assertTrue(exception.getMessage().contains("401 Unauthorized"));
+    }
+}


### PR DESCRIPTION
Closes: #42 
Create a service that will get all of the meals served in a particular dining commons on a particular date
(Meal refers to breakfast, lunch, dinner....)


https://dining.dokku-15.cs.ucsb.edu/swagger-ui/index.html#/UCSBAPIMenuController/getMeals
![image](https://github.com/user-attachments/assets/1028096f-32b9-434f-a50f-719b03714d8b)
(a valid diningCommonsCode could be de-la-guerra)