### PR TITLE
Added placeholder page for individual dining commons

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,6 +16,7 @@ import PlaceholderCreatePage from "main/pages/Placeholder/PlaceholderCreatePage"
 import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
 import MenuItemPage from "main/pages/MenuItem/MenuItemPage";
+import DiningCommonsPage from "main/pages/DiningCommons/DiningCommonsPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -104,6 +105,15 @@ function App() {
               exact
               path="/diningcommons/:date-time/:dining-commons-code/:meal"
               element={<MenuItemPage />}
+            />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route
+              exact
+              path="/diningcommons/:diningCommonsCode"
+              element={<DiningCommonsPage />}
             />
           </>
         )}

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -75,6 +75,12 @@ export default function AppNavbar({
                   >
                     Menu Items
                   </Nav.Link>
+                  <Nav.Link
+                    as={Link}
+                    to="/diningcommons/:diningCommonsCode"
+                  >
+                    Dining Commons
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/DiningCommons/DiningCommonsPage.js
+++ b/frontend/src/main/pages/DiningCommons/DiningCommonsPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function DiningCommonsPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Placeholder for Dining Commons Page</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/DiningCommons/DiningCommonsPage.test.js
+++ b/frontend/src/tests/pages/DiningCommons/DiningCommonsPage.test.js
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import DiningCommonsPage from "main/pages/DiningCommons/DiningCommonsPage";
+
+describe("PlaceholderIndexPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <DiningCommonsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Placeholder for Dining Commons Page");
+
+    // assert
+    expect(
+      screen.getByText("Placeholder for Dining Commons Page"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #25

Added a placeholder page that will originally show the title "Placeholder for Dining Commons Page". Can be accessed by the navbar after logging into Swagger or the route: /diningcommons/:diningCommonsCode.

Changes:
- link in Navbar that takes you to placeholder dining commons page
- placeholder dining commons page

Dokku Link: https://proj-dining-ranjanbhavya.dokku-15.cs.ucsb.edu
<img width="623" alt="image" src="https://github.com/user-attachments/assets/239b79d5-e753-440c-9193-e3a2ea0812d3">
<img width="1343" alt="image" src="https://github.com/user-attachments/assets/d3984325-c819-49c3-8f8d-3b609f605288">

