### PR TITLE
Added Reviews placeholder page and tests, adjusted App.js

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -120,11 +120,7 @@ function App() {
         )}
         {hasRole(currentUser, "ROLE_USER") && (
           <>
-            <Route
-              exact
-              path="/reviews/:itemid"
-              element={<ReviewsPage />}
-            />
+            <Route exact path="/reviews/:itemid" element={<ReviewsPage />} />
           </>
         )}
       </Routes>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -17,6 +17,7 @@ import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 
 import MenuItemPage from "main/pages/MenuItem/MenuItemPage";
 import DiningCommonsPage from "main/pages/DiningCommons/DiningCommonsPage";
+import ReviewsPage from "main/pages/Reviews/ReviewsPage";
 
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
@@ -114,6 +115,15 @@ function App() {
               exact
               path="/diningcommons/:diningCommonsCode"
               element={<DiningCommonsPage />}
+            />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route
+              exact
+              path="/reviews/:itemid"
+              element={<ReviewsPage />}
             />
           </>
         )}

--- a/frontend/src/main/pages/Reviews/ReviewsPage.js
+++ b/frontend/src/main/pages/Reviews/ReviewsPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function ReviewsPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Reviews page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/Reviews/ReviewsPage.test.js
+++ b/frontend/src/tests/pages/Reviews/ReviewsPage.test.js
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import ReviewsPage from "main/pages/Reviews/ReviewsPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("ReviewsPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <ReviewsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Reviews page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Reviews page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
closes: #31 

Added a placeholder page that will display reviews eventually. Right now, it can be accessed via the route /reviews/:itemid.

Frontend changes:
- placeholder reviews page

Test that 
- you can access the placeholder page using that route when logged in

![Screenshot 2024-11-25 223451](https://github.com/user-attachments/assets/251b50b8-a441-4391-980c-b5ec5c880b9d)

Dokku: https://dining.dokku-15.cs.ucsb.edu/