### PR TITLE
Added MyReviews placeholder page and tests, adjusted App.js, AppNavbar.js

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,6 +18,8 @@ import PlaceholderEditPage from "main/pages/Placeholder/PlaceholderEditPage";
 import MenuItemPage from "main/pages/MenuItem/MenuItemPage";
 import DiningCommonsPage from "main/pages/DiningCommons/DiningCommonsPage";
 
+import MyReviewsPage from "main/pages/MyReviews/MyReviewsPage";
+
 import { hasRole, useCurrentUser } from "main/utils/currentUser";
 
 import "bootstrap/dist/css/bootstrap.css";
@@ -115,6 +117,11 @@ function App() {
               path="/diningcommons/:diningCommonsCode"
               element={<DiningCommonsPage />}
             />
+          </>
+        )}
+        {hasRole(currentUser, "ROLE_USER") && (
+          <>
+            <Route exact path="/myreviews" element={<MyReviewsPage />} />
           </>
         )}
       </Routes>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -124,7 +124,6 @@ function App() {
             element={<DiningCommonsPage />}
           />
         </>
-
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -78,6 +78,9 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/diningcommons/:diningCommonsCode">
                     Dining Commons
                   </Nav.Link>
+                  <Nav.Link as={Link} to="/myreviews">
+                    My Reviews
+                  </Nav.Link>
                 </>
               ) : (
                 <></>

--- a/frontend/src/main/pages/MyReviews/MyReviewsPage.js
+++ b/frontend/src/main/pages/MyReviews/MyReviewsPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function MyReviewsPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>This page will eventually show all reviews entered by the user</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/MyReviews/MyReviewsPage.test.js
+++ b/frontend/src/tests/pages/MyReviews/MyReviewsPage.test.js
@@ -1,0 +1,52 @@
+import { render, screen } from "@testing-library/react";
+import MyReviewsPage from "main/pages/MyReviews/MyReviewsPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("MyReviewsPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MyReviewsPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText(
+      "This page will eventually show all reviews entered by the user",
+    );
+
+    // assert
+    expect(
+      screen.getByText(
+        "This page will eventually show all reviews entered by the user",
+      ),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
closes: #26 

Added a placeholder page that will eventually show all reviews entered by the user. Right now, it can be accessed via the navbar through the "My Reviews" button and the route /myreviews.

Frontend changes:
- new link in Navbar that takes you to the placeholder My Reviews page.
- placeholder My Reviews page

Test that 
- the "My Reviews" button in the navbar takes you to the My Reviews placeholder page
- you can access the placeholder page using the route /myreviews when logged in

![image](https://github.com/user-attachments/assets/8d491958-eb17-452a-8dea-b546a12fc0dc)

Storybook link: https://6736bc30cc8f2118f61238ed-qrgwyaomhu.chromatic.com/?path=/docs/pages-homepage--docs

Dokku: https://dining-qa.dokku-15.cs.ucsb.edu/